### PR TITLE
✨ feat: Add Portuguese and Hindi language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,18 @@ make run SRT=srt/korean.srt ARGS='--gtts-only --lang ko'
 make run SRT=srt/indonesian.srt ARGS='--gtts-only --lang id'
 ```
 
+#### ポルトガル語（Português）
+
+```bash
+make run SRT=srt/portuguese.srt ARGS='--gtts-only --lang pt'
+```
+
+#### ヒンディー語（हिन्दी）
+
+```bash
+make run SRT=srt/hindi.srt ARGS='--gtts-only --lang hi'
+```
+
 ### オーディオタグ付きJSONのみ出力（TTS無し）
 
 開発・デバッグ用にTTSをスキップしてJSONのみを出力：
@@ -152,7 +164,7 @@ make clean   # Dockerイメージを削除
 | オプション | デフォルト | 説明 |
 |-----------|-----------|------|
 | `--gtts-only` | - | gTTSのみで音声生成（ElevenLabsを使用しない） |
-| `--lang` | ja | gTTSの言語コード（例: en, ja, ko, zh-CN, ru, es, id） |
+| `--lang` | ja | gTTSの言語コード（例: en, ja, ko, zh-CN, ru, es, id, pt, hi） |
 | `--estimation-ratio` | 1.0 | gTTS事前見積もりの補正係数（0以下で無効化） |
 | `--gtts-shorten-retries` | 4 | gTTS事前見積もりでの再意訳リトライ回数 |
 | `--el-shorten-retries` | 2 | ElevenLabs生成後の再意訳リトライ回数 |

--- a/src/validators/language.py
+++ b/src/validators/language.py
@@ -20,6 +20,8 @@ LANG_CODE_MAP: dict[str, Language] = {
     "ru": Language.RUSSIAN,
     "es": Language.SPANISH,
     "id": Language.INDONESIAN,
+    "pt": Language.PORTUGUESE,
+    "hi": Language.HINDI,
 }
 
 


### PR DESCRIPTION
## Summary

- ポルトガル語 (`pt`) とヒンディー語 (`hi`) のサポートを追加
- Phase 2 の多言語サポート拡張 (#6)

### 変更内容

- `src/validators/language.py`: 言語バリデーション用マッピングに `pt`, `hi` を追加
- `README.md`: 使用例と `--lang` オプション説明を更新

## Test plan

- [ ] `make run SRT=srt/portuguese.srt ARGS='--gtts-only --lang pt'` でポルトガル語の音声生成を確認
- [ ] `make run SRT=srt/hindi.srt ARGS='--gtts-only --lang hi'` でヒンディー語の音声生成を確認
- [ ] 言語バリデーションが正しく動作することを確認

## Related

Closes #6 (Phase 2)

🤖 Generated with [Claude Code](https://claude.ai/code)